### PR TITLE
Move process and changeEvent handlers to inside spellcheck. Add mutex…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,7 @@
     "typo-js": "^1.2.5",
     "vite": "^6.0.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "async-mutex": "^0.5.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,13 @@
   resolved "https://registry.npmjs.org/@types/typo-js/-/typo-js-1.2.2.tgz#e9bbb21e3c0d986a6b869f9f43897caa48511912"
   integrity sha512-AgN5IwO3EPXv2d+UE9VdoOcueCBa4ZcHHwUvx2/IXlfRvkW4Yt3g+eRHzJbkySfj9pyILRT6Zk7V6Vr4LD5Kvg==
 
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.5.0.tgz#353c69a0b9e75250971a64ac203b0ebfddd75482"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
 esbuild@^0.24.2:
   version "0.24.2"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz#b5b55bee7de017bff5fb8a4e3e44f2ebe2c3567d"
@@ -324,6 +331,11 @@ source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 typescript@~5.6.2:
   version "5.6.3"


### PR DESCRIPTION
* Fixes https://github.com/purocean/monaco-spellchecker/issues/2 which is an issue when re-registering after a dispose with a new editor instance
* Move `onDidChangeModelContent` to register inside the spellchecker so that it can be disposed with the rest of the spellchecker. Allows simpler registration.
* Debounce process internally for convenience. Adds new `debounceInterval` option.
* Add mutex around dictionary operations in the callee rather than explicit delays. This improves performance and elminations possible corruption is multiple async process events execute in parallel. 
* Adds semicolons to line endings to avoid possible issues with JS automatic semicolon insertion
* Demonstrate proper dispose of spellchecker in example
* Suggest nspell over typo.js for performance in a comment in the example. I did not switch to nspell as the dictionaries are harder to work with. I recommend the open source chrome word lists instead, however those are GPL so cannot be included in the repository.

Tested all changes and working :smile: thanks for the example of how to extend monaco to support spellcheck. Great work!